### PR TITLE
Fix VS Code markdown redering on button click

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ setuptools.setup(
     package_dir={"": "src"},
     packages=setuptools.find_packages(where="src"),
     python_requires=">=3.7",
-    install_requires=["python-dotenv", "requests", "ipython", "ipywidgets"],
+    install_requires=["python-dotenv", "requests", "ipython", "ipywidgets<=7.8.5"],
 )


### PR DESCRIPTION
In VS Code notebooks, when clicking the button to send activities for correction on the server, Markdown rendering does not occur.

We noticed that with version `ipywidgets<=7.8.5` the error does not occur. The lib version was fixed in the setup.